### PR TITLE
Fix definitions of *spevx

### DIFF
--- a/bin/c.py
+++ b/bin/c.py
@@ -56,7 +56,6 @@ def is_scalar(name, cty, f):
         ] or
         name.startswith("alpha") or
         name.startswith("beta") or
-        name.startswith("ifail") or
         name.startswith("inc") or
         name.startswith("k") or
         name.startswith("ld") or

--- a/bin/fortran.py
+++ b/bin/fortran.py
@@ -62,7 +62,6 @@ def is_scalar(name, cty, f):
         ] or
         name.startswith("alpha") or
         name.startswith("beta") or
-        name.startswith("ifail") or
         name.startswith("inc") or
         name.startswith("k") or
         name.startswith("ld") or


### PR DESCRIPTION
The definitions of *spevx had `ifail` as a `&mut i32`, but it should actually be a `&mut [i32]` since it returns the array of indices of eigenvectors that failed to converge. See netlib reference: http://www.netlib.org/lapack/explore-3.1.1-html/dspevx.f.html